### PR TITLE
sleepy预设细节优化

### DIFF
--- a/config_webhook.json
+++ b/config_webhook.json
@@ -16,7 +16,7 @@
         "triggers": [
             "disconnected"
         ],
-        "body": "{\n    \"id\": \"heart-rate-widget\",\n    \"show_name\": \"♥️\",\n    \"using\": false,\n    \"app_name\": \"{bpm}bpm\"\n}",
+        "body": "{\n    \"id\": \"heart-rate-widget\",\n    \"show_name\": \"❤\",\n    \"using\": false,\n    \"app_name\": \"{bpm}bpm\"\n}",
         "headers": "{\n    \"Content-Type\": \"application/json\",\n    \"Sleepy-Secret\": \"改成你的秘钥\"\n}"
     }
 ]

--- a/config_webhook.json
+++ b/config_webhook.json
@@ -6,7 +6,7 @@
         "triggers": [
             "heart_rate_updated"
         ],
-        "body": "{\n    \"id\": \"heart-rate-widget\",\n    \"show_name\": \"❤\",\n    \"using\": true,\n    \"app_name\": \"{bpm}\"\n}",
+        "body": "{\n    \"id\": \"heart-rate-widget\",\n    \"show_name\": \"♥️\",\n    \"using\": true,\n    \"app_name\": \"{bpm}bpm\"\n}",
         "headers": "{\n    \"Content-Type\": \"application/json\",\n    \"Sleepy-Secret\": \"改成你的秘钥\"\n}"
     },
     {
@@ -16,7 +16,7 @@
         "triggers": [
             "disconnected"
         ],
-        "body": "{\n    \"id\": \"heart-rate-widget\",\n    \"show_name\": \"❤\",\n    \"using\": false,\n    \"app_name\": \"未在使用\"\n}",
+        "body": "{\n    \"id\": \"heart-rate-widget\",\n    \"show_name\": \"♥️\",\n    \"using\": false,\n    \"app_name\": \"{bpm}bpm\"\n}",
         "headers": "{\n    \"Content-Type\": \"application/json\",\n    \"Sleepy-Secret\": \"改成你的秘钥\"\n}"
     }
 ]


### PR DESCRIPTION
啊哈我来水个pr（
断开时的app_name也能够直接设置为{bpm}，这样子sleepy会根据用户设置的[sleepy_status_not_using](https://github.com/sleepy-project/sleepy/blob/main/doc/env.md#status-%E9%A1%B5%E9%9D%A2%E7%8A%B6%E6%80%81%E6%98%BE%E7%A4%BA%E9%85%8D%E7%BD%AE)显示，如果没有设置则是将最后活跃的app_name值变灰展现，能看到似前最后的心率（×
<img width="765" height="348" alt="image" src="https://github.com/user-attachments/assets/cf45ce4b-6480-4927-ae4e-ebf8fc71aebc" />
然后将默认的Emoji由❤换到了♥️，因为他能彩色渲染显示（
但是在咱们程序内好像有点问题，会这样
<img width="514" height="184" alt="image" src="https://github.com/user-attachments/assets/42dc14d2-acf8-48a7-b161-bf78149a9f17" />

可能要修一下（（